### PR TITLE
chore(devcontainer): update Node.js version and simplify MCP configuration (fixes #27)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,18 +21,18 @@
 			"terragrunt": "latest"
 		},
 		"ghcr.io/devcontainers/features/node:1": {
-			"version": "lts"
+			"version": "22"
 		}
-	}
+	},
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "npm install -g @github/copilot"
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
-
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "pip3 install --user -r requirements.txt",
 
 	// Configure tool-specific properties.
 	// "customizations": {},

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,37 +1,3 @@
 {
-	"servers": {
-		"github": {
-			"type": "http",
-			"url": "https://api.githubcopilot.com/mcp/"
-		},
-		"microsoft.docs.mcp": {
-			"type": "http",
-			"url": "https://learn.microsoft.com/api/mcp"
-		},
-		"microsoft/azure-devops-mcp": {
-			"type": "stdio",
-			"command": "npx",
-			"args": [
-				"-y",
-				"@azure-devops/mcp@latest",
-				"${input:ado_org}",
-				"-d",
-				"${input:ado_domain}"
-			],
-		}
-	},
-	"inputs": [
-		{
-			"id": "ado_org",
-			"type": "promptString",
-			"description": "Azure DevOps organization name (e.g., contoso).",
-			"password": false
-		},
-		{
-			"id": "ado_domain",
-			"type": "promptString",
-			"description": "Repeat to enable specific domains: core, work, work-items, search, test-plans, repositories, wiki, pipelines, advanced-security.",
-			"password": false
-		}
-	]
+	"servers": {}
 }


### PR DESCRIPTION
## Changes
Updated development container and MCP configuration for improved consistency and maintainability:

- **Node.js version**: Pinned to version 22 instead of 'lts' for consistency
- **postCreateCommand**: Added to automatically install GitHub Copilot CLI globally (`npm install -g @github/copilot`)
- **MCP configuration**: Simplified `.vscode/mcp.json` to empty servers configuration
- **Removed**: GitHub, Microsoft Docs, and Azure DevOps MCP server configurations

## Related Issue
Fixes #27

## Testing
- [x] Changes follow conventional commit format
- [x] Commit message references issue #27
- [x] No Terraform code changes (devcontainer only)
- [x] Configuration files are valid JSON

## Review Checklist
- [x] Code follows repository conventions
- [x] Configuration files properly formatted
- [x] No sensitive values exposed
- [x] Documentation updated (if needed)

## Notes
These changes streamline the development environment setup and MCP server configuration. The postCreateCommand ensures GitHub Copilot CLI is available immediately after container creation.