### PR TITLE
feat(cicd): populate hub integration variables for Day 2

### DIFF
--- a/infra/terraform/cicd/prod.tfvars
+++ b/infra/terraform/cicd/prod.tfvars
@@ -32,21 +32,20 @@ state_storage_account_id = "/subscriptions/f8a5f387-2f0b-42f5-b71f-5ee02b8967cf/
 # platform_key_vault_id = "<set-by-pipeline-or-manually>"
 
 # =============================================================================
-# Hub Integration — Day 2 (leave empty/commented for bootstrap, populate after hub exists)
+# Hub Integration — Day 2
 # =============================================================================
-# After hub is deployed, populate these values and re-apply CI/CD to add:
+# Populated from hub terraform outputs. Enables:
 #   - Bidirectional VNet peering (CI/CD ↔ hub)
 #   - Custom DNS (hub resolver IP) replacing Azure default DNS
 #   - Hub DNS zones replacing CI/CD-owned zones
 #   - Hub+Spoke SA private endpoint for self-hosted agent access
-#
-# hub_vnet_id                        = "/subscriptions/.../providers/Microsoft.Network/virtualNetworks/vnet-hub-prod-eus2"
-# hub_dns_resolver_ip                = "10.0.6.4"
-# hub_acr_dns_zone_id                = "/subscriptions/.../providers/Microsoft.Network/privateDnsZones/privatelink.azurecr.io"
-# hub_blob_dns_zone_id               = "/subscriptions/.../providers/Microsoft.Network/privateDnsZones/privatelink.blob.core.windows.net"
-# hub_vault_dns_zone_id              = "/subscriptions/.../providers/Microsoft.Network/privateDnsZones/privatelink.vaultcore.azure.net"
-# hub_log_analytics_workspace_id     = "/subscriptions/.../providers/Microsoft.OperationalInsights/workspaces/law-hub-prod-eus2"
-# hub_spoke_state_storage_account_id = "/subscriptions/.../providers/Microsoft.Storage/storageAccounts/<hub-spoke-sa-name>"
+hub_vnet_id                        = "/subscriptions/f8a5f387-2f0b-42f5-b71f-5ee02b8967cf/resourceGroups/rg-hub-eus2-prod/providers/Microsoft.Network/virtualNetworks/vnet-hub-prod-eus2"
+hub_dns_resolver_ip                = "10.0.6.4"
+hub_acr_dns_zone_id                = "/subscriptions/f8a5f387-2f0b-42f5-b71f-5ee02b8967cf/resourceGroups/rg-hub-eus2-prod/providers/Microsoft.Network/privateDnsZones/privatelink.azurecr.io"
+hub_blob_dns_zone_id               = "/subscriptions/f8a5f387-2f0b-42f5-b71f-5ee02b8967cf/resourceGroups/rg-hub-eus2-prod/providers/Microsoft.Network/privateDnsZones/privatelink.blob.core.windows.net"
+hub_vault_dns_zone_id              = "/subscriptions/f8a5f387-2f0b-42f5-b71f-5ee02b8967cf/resourceGroups/rg-hub-eus2-prod/providers/Microsoft.Network/privateDnsZones/privatelink.vaultcore.azure.net"
+hub_log_analytics_workspace_id     = "/subscriptions/f8a5f387-2f0b-42f5-b71f-5ee02b8967cf/resourceGroups/rg-hub-eus2-prod/providers/Microsoft.OperationalInsights/workspaces/law-hub-prod-eus2"
+hub_spoke_state_storage_account_id = "/subscriptions/f8a5f387-2f0b-42f5-b71f-5ee02b8967cf/resourceGroups/rg-tfstate-eus2-prod/providers/Microsoft.Storage/storageAccounts/sttfstateeus2257fb243"
 
 # Resource tags
 tags = {


### PR DESCRIPTION
## Summary\n\nPopulates hub integration variables in CI/CD `prod.tfvars` with actual hub Terraform output values. This is the **CI/CD Day 2** step in the bootstrap-first deployment workflow.\n\n## Changes\n\n**File:** `infra/terraform/cicd/prod.tfvars`\n\nUncomments and fills hub integration variables with live hub outputs:\n\n| Variable | Value |\n|---|---|\n| `hub_vnet_id` | `.../virtualNetworks/vnet-hub-prod-eus2` |\n| `hub_dns_resolver_ip` | `10.0.6.4` |\n| `hub_acr_dns_zone_id` | `.../privateDnsZones/privatelink.azurecr.io` |\n| `hub_blob_dns_zone_id` | `.../privateDnsZones/privatelink.blob.core.windows.net` |\n| `hub_vault_dns_zone_id` | `.../privateDnsZones/privatelink.vaultcore.azure.net` |\n| `hub_log_analytics_workspace_id` | `.../workspaces/law-hub-prod-eus2` |\n| `hub_spoke_state_storage_account_id` | `.../storageAccounts/sttfstateeus2257fb243` |\n\n## What this enables (after pipeline runs)\n\n- ➕ Bidirectional VNet peering (CI/CD ↔ Hub)\n- ➕ Custom DNS on CI/CD VNet → hub resolver (10.0.6.4)\n- ➕ Hub+Spoke state SA private endpoint\n- ➕ Hub Log Analytics workspace for centralized monitoring\n- ➖ CI/CD-owned DNS zones destroyed (blob, vault, ACR) — hub zones take over\n\n## Deployment context\n\n```\nPhase 1: CI/CD Bootstrap (MS-hosted) ✅ Done\nPhase 2: UAMI Registration in ADO    ✅ Done\nPhase 3: Hub (self-hosted)            ✅ Done\nPhase 4: CI/CD Day 2 (self-hosted)    ⬅️ This PR\nPhase 5: Spoke (self-hosted)          ⬜ After this\n```\n\n## Validation\n\n- `terraform fmt -check` ✅\n- `terraform validate` ✅\n- Values sourced from `terraform output -json` on hub state\n\n## Post-merge steps\n\n1. Run `cicd-deploy` pipeline with `useSelfHosted=true`\n2. Verify peering, DNS, and PE health\n3. Proceed to spoke deployment