### PR TITLE
fix(cicd): warn that Day 2 must run on MS-hosted agents

### DIFF
--- a/pipelines/cicd-deploy.yml
+++ b/pipelines/cicd-deploy.yml
@@ -6,8 +6,12 @@
 #   2. Set pipeline variable PLATFORM_KV_ID to the platform Key Vault resource ID
 #   3. (Optional) Hub deployed — populate hub variables in prod.tfvars for Day 2 integration
 #
-# First run: Set USE_SELF_HOSTED=false (or leave unset) to use MS-hosted agents.
-# After agents are deployed and registered in ADO, set USE_SELF_HOSTED=true.
+# First run: Set useSelfHosted=false (default) to use MS-hosted agents.
+# After agents are deployed and registered in ADO, set useSelfHosted=true.
+#
+# WARNING: Day 2 hub integration changes (populating hub_* variables in prod.tfvars)
+# modify VNet DNS and DNS zones, which triggers Container App Environment recreation.
+# This DESTROYS the running agent mid-pipeline. Always run Day 2 with useSelfHosted=false.
 
 trigger:
   branches:


### PR DESCRIPTION
## Summary

Documents the constraint that CI/CD Day 2 hub integration **must run on MS-hosted agents** (`useSelfHosted=false`).

## Problem

When Day 2 hub integration variables are populated, Terraform changes VNet DNS servers and destroys CI/CD-owned DNS zones. This triggers Container App Environment recreation, which **destroys the running self-hosted agent mid-pipeline**, leaving the pipeline hung and Terraform state locked.

## Changes

**`pipelines/cicd-deploy.yml`**: Added WARNING comment block explaining the Day 2 constraint.

**`.github/instructions/cicd-deploy.instructions.md`**:
- Updated Phase 4 deployment order to show ⚠️ MS-hosted requirement
- Updated bootstrap sequence table (Phase 4 row)
- Updated dependency graph

## No functional changes — documentation/comments only.