### PR TITLE
feat(cicd): add bidirectional VNet peering to spoke VNets

### DIFF
--- a/infra/terraform/cicd/main.tf
+++ b/infra/terraform/cicd/main.tf
@@ -63,6 +63,8 @@ resource "azurerm_virtual_network_peering" "cicd_to_spoke" {
   allow_forwarded_traffic   = true
 }
 
+# NOTE: CI/CD service principal needs Network Contributor on each spoke RG
+# to create this peering direction (same pattern as hub_to_cicd peering).
 resource "azurerm_virtual_network_peering" "spoke_to_cicd" {
   for_each                  = var.spoke_vnet_ids
   name                      = "peer-${each.key}-to-cicd"

--- a/infra/terraform/cicd/prod.tfvars
+++ b/infra/terraform/cicd/prod.tfvars
@@ -47,6 +47,12 @@ hub_vault_dns_zone_id              = "/subscriptions/f8a5f387-2f0b-42f5-b71f-5ee
 hub_log_analytics_workspace_id     = "/subscriptions/f8a5f387-2f0b-42f5-b71f-5ee02b8967cf/resourceGroups/rg-hub-eus2-prod/providers/Microsoft.OperationalInsights/workspaces/law-hub-prod-eus2"
 hub_spoke_state_storage_account_id = "/subscriptions/f8a5f387-2f0b-42f5-b71f-5ee02b8967cf/resourceGroups/rg-tfstate-eus2-prod/providers/Microsoft.Storage/storageAccounts/sttfstateeus2257fb243"
 
+# Spoke VNet peering — enables CI/CD agents to reach private AKS API servers.
+# Add each spoke VNet here as new spokes are deployed.
+spoke_vnet_ids = {
+  "spoke-aks-prod" = "/subscriptions/f8a5f387-2f0b-42f5-b71f-5ee02b8967cf/resourceGroups/rg-aks-eus2-prod/providers/Microsoft.Network/virtualNetworks/vnet-aks-prod-eus2"
+}
+
 # Resource tags
 tags = {
   Purpose     = "AKS Landing Zone CI/CD"

--- a/infra/terraform/cicd/variables.tf
+++ b/infra/terraform/cicd/variables.tf
@@ -195,6 +195,19 @@ variable "hub_log_analytics_workspace_id" {
   default     = ""
 }
 
+# --- Spoke VNet Peering (for kubectl/Helm access to private AKS clusters) ---
+
+variable "spoke_vnet_ids" {
+  description = "Map of spoke name to VNet resource ID for bidirectional peering. Enables CI/CD agents to reach private AKS API servers. VNet peering is not transitive, so each spoke needs a direct peering."
+  type        = map(string)
+  default     = {}
+
+  validation {
+    condition     = alltrue([for v in values(var.spoke_vnet_ids) : can(regex("^/subscriptions/[^/]+/resourceGroups/[^/]+/providers/Microsoft\\.Network/virtualNetworks/[^/]+$", v))])
+    error_message = "Each spoke_vnet_ids value must be a valid Azure VNet resource ID."
+  }
+}
+
 # --- Tags ---
 
 variable "tags" {


### PR DESCRIPTION
## Summary

Enables CI/CD Container App Job agents to reach private AKS API servers via direct VNet peering.

## Problem

VNet peering is **not transitive** — the existing CI/CD ↔ Hub peering does NOT provide network access to spoke VNets. After DNS resolves the AKS private FQDN to `10.1.4.4`, the Container App Job has no route to reach that IP.

## Solution

Add bidirectional CI/CD ↔ Spoke VNet peering using a `spoke_vnet_ids` map variable. New spokes are added by appending entries to `prod.tfvars` — no Terraform code changes needed.

## Changes

- **`variables.tf`**: New `spoke_vnet_ids` variable (`map(string)`) with validation
- **`main.tf`**: Bidirectional peering resources using `for_each`
- **`prod.tfvars`**: Added `spoke-aks-prod` VNet ID

## Safety

This change **only adds peering resources** — no DNS, subnet, or VNet configuration changes. Safe to deploy from self-hosted agents (no ACA recreation).

## Scalability Note

For environments with many spokes (>5), consider migrating to Azure Virtual WAN for native spoke-to-spoke transit instead of N peerings.