### PR TITLE
fix(spoke): address Copilot review feedback on PR #51

### DIFF
--- a/.github/instructions/cicd-deploy.instructions.md
+++ b/.github/instructions/cicd-deploy.instructions.md
@@ -177,8 +177,8 @@ resource "azurerm_virtual_network_peering" "cicd_to_spoke" {
 resource "azurerm_virtual_network_peering" "spoke_to_cicd" {
   for_each                  = var.spoke_vnet_ids
   name                      = "peer-${each.key}-to-cicd"
-  resource_group_name       = regex("/resourceGroups/([^/]+)/", each.value)[0]
-  virtual_network_name      = regex("/virtualNetworks/([^/]+)$", each.value)[0]
+  resource_group_name       = split("/", each.value)[4]
+  virtual_network_name      = split("/", each.value)[8]
   remote_virtual_network_id = azurerm_virtual_network.cicd.id
   allow_forwarded_traffic   = true
 }

--- a/pipelines/spoke-deploy.yml
+++ b/pipelines/spoke-deploy.yml
@@ -209,15 +209,23 @@ stages:
 
                 echo "=== Waiting for NginxIngressController to be ready ==="
                 # Wait up to 3 minutes for the controller to provision
+                READY=false
                 for i in $(seq 1 18); do
                   STATUS=$(kubectl get nginxingresscontroller nginx-internal -o jsonpath='{.status.controllerReadyReplicas}' 2>/dev/null || echo "0")
                   if [ "$STATUS" != "0" ] && [ -n "$STATUS" ]; then
                     echo "NGINX controller ready with $STATUS replicas"
+                    READY=true
                     break
                   fi
                   echo "Waiting for NGINX controller... (attempt $i/18)"
                   sleep 10
                 done
+
+                if [ "$READY" != "true" ]; then
+                  echo "##[error]NGINX controller did not become ready within 3 minutes"
+                  kubectl get nginxingresscontroller nginx-internal -o yaml 2>/dev/null || true
+                  exit 1
+                fi
 
                 echo ""
                 echo "=== NGINX Ingress Controller Status ==="


### PR DESCRIPTION
Addresses Copilot review feedback from PR #51:

1. **NGINX readiness loop now fails pipeline** — If the controller doesn't become ready within 3 minutes, the pipeline exits with error and dumps controller YAML for debugging
2. **Docs regex→split fix** — CI/CD spec example now uses `split("/", each.value)[4]` matching the actual Terraform implementation instead of `regex()`